### PR TITLE
strerror_r is not available on mingw

### DIFF
--- a/c-api/compat-5.3.c
+++ b/c-api/compat-5.3.c
@@ -28,9 +28,10 @@
 #endif /* VC++ _fsopen for share-allowed file read */
 
 #ifndef COMPAT53_HAVE_STRERROR_R
-#  if (defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 200112L) || \
+#  if (!defined(_WIN32)) && \
+      ((defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 200112L) || \
       (defined(_XOPEN_SOURCE) && _XOPEN_SOURCE >= 600) || \
-      defined(__APPLE__)
+      defined(__APPLE__))
 #    define COMPAT53_HAVE_STRERROR_R 1
 #  else /* none of the defines matched: define to 0 */
 #    define COMPAT53_HAVE_STRERROR_R 0


### PR DESCRIPTION
From a [Mingw CI Run on Windows](https://github.com/teal-language/tl/runs/7588945095?check_suite_focus=true):

```
In file included from c-api/compat-5.3.h:419,
                 from lprefix.h:46,
                 from ltablib.c:10:
c-api/compat-5.3.c: In function 'compat53_strerror':
c-api/compat-5.3.c:60:9: warning: implicit declaration of function 'strerror_r'; did you mean 'strerror_s'? [-Wimplicit-function-declaration]
   60 |     if (strerror_r(en, buff, sz)) {
      |         ^~~~~~~~~~
      |         strerror_s
In file included from c-api/compat-5.3.h:419,
                 from lprefix.h:46,
                 from lstrlib.c:10:
c-api/compat-5.3.c: In function 'compat53_strerror':
c-api/compat-5.3.c:60:9: warning: implicit declaration of function 'strerror_r'; did you mean 'strerror_s'? [-Wimplicit-function-declaration]
   60 |     if (strerror_r(en, buff, sz)) {
      |         ^~~~~~~~~~
      |         strerror_s
In file included from c-api/compat-5.3.h:419,
                 from lprefix.h:46,
                 from lutf8lib.c:10:
c-api/compat-5.3.c: In function 'compat53_strerror':
c-api/compat-5.3.c:60:9: warning: implicit declaration of function 'strerror_r'; did you mean 'strerror_s'? [-Wimplicit-function-declaration]
   60 |     if (strerror_r(en, buff, sz)) {
      |         ^~~~~~~~~~
      |         strerror_s
```

See also: 
* https://jira.mongodb.org/browse/CDRIVER-1982
* https://sourceforge.net/p/mingw-w64/bugs/513/
