### PR TITLE
Fix missing closing parenthesis in preprocessor macro

### DIFF
--- a/lprefix.h
+++ b/lprefix.h
@@ -199,7 +199,7 @@ LUAMOD_API int luaopen_compat53_string (lua_State *L) {
       (defined(_XOPEN_SOURCE) && _XOPEN_SOURCE >= 600) || \
       defined(__APPLE__)
 #    define LUA_USE_POSIX 1
-#  elif (defined(_MSC_VER)
+#  elif (defined(_MSC_VER))
 #    define LUA_USE_WINDOWS 0
 #  endif
 


### PR DESCRIPTION
Fixes this:

```In file included from liolib.c:10:0:
lprefix.h:201:0: warning: "LUA_USE_POSIX" redefined [enabled by default]
 #    define LUA_USE_POSIX 1
 ^
In file included from /usr/include/lua.h:16:0,
                 from c-api/compat-5.3.h:10,
                 from lprefix.h:46,
                 from liolib.c:10:
/usr/include/luaconf.h:21:0: note: this is the location of the previous definition
 #define LUA_USE_POSIX
 ^
In file included from liolib.c:10:0:
lprefix.h:202:9: error: missing ')' in expression
 #  elif (defined(_MSC_VER)
```