### PR TITLE
Fix Symbol Visibility

### DIFF
--- a/lprefix.h
+++ b/lprefix.h
@@ -46,8 +46,11 @@
 #include "c-api/compat-5.3.h"
 
 #undef LUAMOD_API
-#define LUAMOD_API __attribute__((visibility("default"))) extern
-
+#if defined(__GNUC__)
+#  define LUAMOD_API __attribute__((visibility("default"))) extern
+#else
+#  define LUAMOD_API extern
+#endif
 
 #ifdef lutf8lib_c
 #  define luaopen_utf8 luaopen_compat53_utf8

--- a/lprefix.h
+++ b/lprefix.h
@@ -46,7 +46,7 @@
 #include "c-api/compat-5.3.h"
 
 #undef LUAMOD_API
-#define LUAMOD_API extern
+#define LUAMOD_API __attribute__((visibility("default"))) extern
 
 
 #ifdef lutf8lib_c
@@ -165,7 +165,7 @@ LUAMOD_API int luaopen_compat53_string (lua_State *L) {
  */
 #  undef LUAMOD_API
 #  if defined(__GNUC__) || __has_attribute(__unused__)
-#    define LUAMOD_API __attribute__((__unused__)) static
+#    define LUAMOD_API __attribute__((__unused__, visibility("default"))) static
 #  else
 #    define LUAMOD_API static
 #  endif
@@ -274,7 +274,7 @@ LUAMOD_API int luaopen_compat53_io (lua_State *L) {
  */
 #  undef LUAMOD_API
 #  if defined(__GNUC__) || __has_attribute(__unused__)
-#    define LUAMOD_API __attribute__((__unused__)) static
+#    define LUAMOD_API __attribute__((__unused__, visibility("default"))) static
 #  else
 #    define LUAMOD_API static
 #  endif


### PR DESCRIPTION
Explicitly marks API symbols with __attribute__((visibility("default")) on GNU compatible compilers. When building with -fvisibility=hidden, LTO, etc., each lib had its symbol hidden. 

This ensures the shared libraries will respectively export luaopen_compat53_io, luaopen_compat53_string, luaopen_compat53_table, and luaopen_compat53_utf8.                   