### PR TITLE
ci: Remove luarocks lint of a specific rockspec

### DIFF
--- a/.github/workflows/compat53-tests.yml
+++ b/.github/workflows/compat53-tests.yml
@@ -90,7 +90,6 @@ jobs:
         with:
           luaRocksVersion: "3.13.0"
       - run: lua -v && luarocks --version
-      - run: luarocks lint rockspecs/compat53-0.14.4-1.rockspec
       - run: luarocks lint rockspecs/compat53-scm-1.rockspec
       # Install the local version of compat53.
       - run: luarocks --local make rockspecs/compat53-scm-1.rockspec


### PR DESCRIPTION
The first lint job is fragile when a luarocks version changes.  Let's drop the first lint but keep the second.
```diff
-     - run: luarocks lint rockspecs/compat53-0.14.4-1.rockspec
      - run: luarocks lint rockspecs/compat53-scm-1.rockspec
```
---
### Why are the lua5.5 --check-lua-versions installs still failing?

% `luarocks install --check-lua-versions compat53`
 ```
  env:
    LUA_PATH: ;;/Users/runner/.luarocks/share/lua/5.5/?.lua;/Users/runner/.luarocks/share/lua/5.5/?/init.lua;/Users/runner/work/lua-compat-5.3/lua-compat-5.3/.luarocks/share/lua/5.5/?.lua;/Users/runner/work/lua-compat-5.3/lua-compat-5.3/.luarocks/share/lua/5.5/?/init.lua
    LUA_CPATH: ;;/Users/runner/.luarocks/lib/lua/5.5/?.so;/Users/runner/work/lua-compat-5.3/lua-compat-5.3/.luarocks/lib/lua/5.5/?.so
In file included from lutf8lib.c:10:
In file included from ./lprefix.h:46:
./c-api/compat-5.3.h:401:4: error: "unsupported Lua version (i.e. not Lua 5.1, 5.2, 5.3, or 5.4)"
  401 | #  error "unsupported Lua version (i.e. not Lua 5.1, 5.2, 5.3, or 5.4)"
      |    ^
1 error generated.

Error: Build error: Failed compiling object lutf8lib.o
Installing https://luarocks.org/compat53-0.15.0-1.src.rock
```