### PR TITLE
Keep GitHub Actions up to date with GitHub's Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# Keep GitHub Actions up to date with GitHub's Dependabot...
+# https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/secure-your-dependencies/auto-update-actions
+# https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#package-ecosystem
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    groups:
+      github-actions:
+        patterns:
+          - "*"  # Group all Actions updates into a single larger pull request
+    schedule:
+      interval: weekly
+    cooldown:  # https://nesbitt.io/2026/03/04/package-managers-need-to-cool-down.html
+      default-days: 7


### PR DESCRIPTION
* [Keeping your software supply chain secure with Dependabot](https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain)
* [Keeping your actions up to date with Dependabot](https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/secure-your-dependencies/auto-update-actions)
* [Configuration options for the `dependabot.yml` file - package-ecosystem](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#package-ecosystem-)

To see all GitHub Actions dependencies, type:
% `git grep 'uses: ' .github/workflows/`
```
.github/workflows/bit32-multi-arch-tests.yml:      - uses: actions/checkout@v6
.github/workflows/bit32-multi-arch-tests.yml:      - uses: actions/cache@v4
.github/workflows/bit32-multi-arch-tests.yml:      - uses: uraimo/run-on-arch-action@v3
.github/workflows/compat53-tests.yml:      - uses: actions/checkout@v6
.github/workflows/compat53-tests.yml:      - uses: actions/checkout@v7
.github/workflows/compat53-tests.yml:      - uses: luarocks/gh-actions-lua@master
.github/workflows/compat53-tests.yml:      - uses: luarocks/gh-actions-luarocks@master
```

This will generate a PR to fix the warnings at the bottom of:
* https://github.com/lunarmodules/lua-compat-5.3/actions/runs/29191718758

The GitHub Actions failures are unrelated and are discussed at:
* #82