### PR TITLE
Add lua5.5 to c-api/compat-5.3.h

### DIFF
--- a/c-api/compat-5.3.h
+++ b/c-api/compat-5.3.h
@@ -416,7 +416,7 @@ COMPAT53_API void luaL_requiref (lua_State *L, const char *modname,
 
 
 /* other Lua versions */
-#if !defined(LUA_VERSION_NUM) || LUA_VERSION_NUM < 501 || LUA_VERSION_NUM > 505
+#if !defined(LUA_VERSION_NUM) || LUA_VERSION_NUM < 501 || LUA_VERSION_NUM > 506
 
 #  error "unsupported Lua version (i.e. not Lua 5.1, 5.2, 5.3, 5.4, or 5.5)"
 


### PR DESCRIPTION
Was this fixed in the [v0.15.1 release](https://luarocks.org/modules/lunarmodules/compat53)?!?

Let's fix `luarocks --lua-version=5.5 install --check-lua-versions compat53`

And failing lua5.5 GitHub Actions like https://github.com/lunarmodules/lua-compat-5.3/actions/runs/29290073036
```diff
- #if !defined(LUA_VERSION_NUM) || LUA_VERSION_NUM < 501 || LUA_VERSION_NUM > 505
+ #if !defined(LUA_VERSION_NUM) || LUA_VERSION_NUM < 501 || LUA_VERSION_NUM > 506
```
It looks like other code in this file was modified for lua5.5 but this line was not.

Related to:
* #79
* #80  Added the ci tests that now finally pass.
* #82 